### PR TITLE
Remove reliance on remote backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env
+.idea/
 .terraform/
 coverage/
 venv/

--- a/test/README.MD
+++ b/test/README.MD
@@ -16,15 +16,9 @@ go mod tidy
 
 # How to run the tests locally
 
-Initialise terraform workspace within the `test/unit-test` directory
-
-```
-cd test/unit-test
-```
-
 Run the tests from within the `test` directory using the `testing-ci` user credentials.
 
-Get the crededtials from secrets manager using the helper script in the modernisation-platform main repo.
+Get the credentials from secrets manager using the helper script in the modernisation-platform main repo.
 
 ```
 cd modernisation-platform/scripts/internal/


### PR DESCRIPTION
Relevant Issue: https://github.com/ministryofjustice/modernisation-platform/issues/2647

Because the infrastructure created by terratest code is transient and to minimise the overhead of managing additional terraform state, the terratest code is being shifted to use local backend that doesn't persist the state between runs. The change makes the use of terraform workspaces irrelevant.

* Update go-terratest workflow to remove the code explicitly selecting a workspace
* Update README.md in the test folder to remove references to terraform workspaces
* Update go code to remove set workspace command and merge Init + Apply back into one statement
* Remove backend.tf from unit-test code
* Update providers.tf to remove references to terraform.worspace
Additionally some minor changes for consistency and neatness.