### PR TITLE
Prepopulated subject claim field

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -5,8 +5,13 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   docs:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # v3.5.1

--- a/.github/workflows/go-terratest.yml
+++ b/.github/workflows/go-terratest.yml
@@ -14,10 +14,8 @@ jobs:
     name: Run Go Unit Tests
     runs-on: ubuntu-latest
     steps:
-dependabot/github_actions/actions/setup-go-4.0.0
       - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
-    main
         with:
           go-version: 1.18
       - uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3

--- a/main.tf
+++ b/main.tf
@@ -28,7 +28,7 @@ data "aws_iam_policy_document" "this" {
     condition {
       test     = "StringLike"
       variable = "token.actions.githubusercontent.com:sub"
-      values   = formatlist("repo:%s", var.github_repositories)
+      values   = formatlist("repo:%s:*", var.github_repositories)
     }
   }
 }

--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -1,5 +1,7 @@
 
 module "module_test" {
+  #checkov:skip=CKV_AWS_274
+  #checkov:skip=CKV_AWS_358
   source              = "../../"
   github_repositories = ["ministryofjustice/modernisation-platform-environments", "ministryofjustice/modernisation-platform"]
   role_name           = "modernisation-platform-github-actions"
@@ -14,6 +16,7 @@ data "aws_iam_policy_document" "first-policy" {
   #checkov:skip=CKV_AWS_109
   #checkov:skip=CKV_AWS_111
   #checkov:skip=CKV_AWS_110
+  #checkov:skip=CKV_AWS_356
   version = "2012-10-17"
 
   statement {

--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -17,6 +17,7 @@ data "aws_iam_policy_document" "first-policy" {
   #checkov:skip=CKV_AWS_111
   #checkov:skip=CKV_AWS_110
   #checkov:skip=CKV_AWS_356
+  #checkov:skip=CKV2_AWS_40
   version = "2012-10-17"
 
   statement {

--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -1,7 +1,7 @@
 
 module "module_test" {
   source              = "../../"
-  github_repositories = ["ministryofjustice/modernisation-platform-environments:*", "ministryofjustice/modernisation-platform:*"]
+  github_repositories = ["ministryofjustice/modernisation-platform-environments", "ministryofjustice/modernisation-platform"]
   role_name           = "modernisation-platform-github-actions"
   policy_arns         = ["arn:aws:iam::aws:policy/AdministratorAccess"]
   policy_jsons        = [data.aws_iam_policy_document.first-policy.json, data.aws_iam_policy_document.second-policy.json]


### PR DESCRIPTION
In order to reduce the complexity of using OIDC for authentication, this PR prepopulates the subject claim value with a wildcard.

Examples of rich subject claims can be seen [here](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#example-subject-claims). If we later need to support rich subject claims, we can do so but for now I think a lower bar of entry to using OIDC is a better option.