### PR TITLE
✨ Allow setting `max_session_duration`

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_github_repositories"></a> [github\_repositories](#input\_github\_repositories) | The github repositories, for example ["ministryofjustice/modernisation-platform-environments:*"] | `list(string)` | n/a | yes |
+| <a name="input_max_session_duration"></a> [max\_session\_duration](#input\_max\_session\_duration) | The maximum session duration (in seconds) that you want to set for the specified role. Defaults to 3600 | `number` | `3600` | no |
 | <a name="input_policy_arns"></a> [policy\_arns](#input\_policy\_arns) | List of policy ARNs for the assumable role. Defaults to ["arn:aws:iam::aws:policy/ReadOnlyAccess"] | `list(string)` | <pre>[<br>  "arn:aws:iam::aws:policy/ReadOnlyAccess"<br>]</pre> | no |
 | <a name="input_policy_jsons"></a> [policy\_jsons](#input\_policy\_jsons) | List of policy jsons for the assumable role. Defaults to [] | `list(string)` | `[]` | no |
 | <a name="input_role_name"></a> [role\_name](#input\_role\_name) | Name of role | `string` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -1,8 +1,8 @@
-
 resource "aws_iam_role" "this" {
-  name               = var.role_name
-  assume_role_policy = data.aws_iam_policy_document.this.json
-  tags               = var.tags
+  name                 = var.role_name
+  assume_role_policy   = data.aws_iam_policy_document.this.json
+  max_session_duration = var.max_session_duration
+  tags                 = var.tags
 }
 
 data "aws_iam_policy_document" "this" {
@@ -38,11 +38,11 @@ resource "aws_iam_role_policy_attachment" "policy-arns" {
   role       = aws_iam_role.this.name
   policy_arn = each.key
 }
+
 data "aws_iam_policy_document" "combined-role-policy" {
   count                   = length(var.policy_jsons) > 0 ? 1 : 0
   source_policy_documents = var.policy_jsons
 }
-
 
 # Add actions missing from arn:aws:iam::aws:policy/ReadOnlyAccess
 resource "aws_iam_policy" "additional-permissions" {

--- a/variables.tf
+++ b/variables.tf
@@ -46,3 +46,13 @@ variable "subject_claim" {
   description = "Github OIDC subject claim, defaults to *"
   default     = "*"
 }
+
+variable "max_session_duration" {
+  type        = number
+  description = "The maximum session duration (in seconds) that you want to set for the specified role. Defaults to 3600"
+  default     = 3600
+  validation {
+    condition     = var.max_session_duration > 0 && var.max_session_duration <= 43200
+    error_message = "Max session duration must be between 1 and 43200 seconds."
+  }
+}


### PR DESCRIPTION
We use this role in Data Platform, but now have a requirement to specify `max_session_duration` longer than `3600` for a long running job in GitHub Actions

Relates to https://github.com/ministryofjustice/data-platform/pull/1941

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk>