### PR TITLE
Removes the use of tee from unit test workflow

### DIFF
--- a/.github/workflows/go-terratest.yml
+++ b/.github/workflows/go-terratest.yml
@@ -27,4 +27,7 @@ jobs:
         run: go mod download
       - name: Run Go Tests
         working-directory: test
-        run: go test -v
+        run: |
+          chmod 700 ../scripts/redact-output.sh
+          go test -v | ../scripts/redact-output.sh
+          exit ${PIPESTATUS[0]}

--- a/scripts/redact-output.sh
+++ b/scripts/redact-output.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Based on: https://github.com/ministryofjustice/opg-org-infra/blob/main/scripts/redact_output.sh
+
+sed -e 's/AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
+    -e 's/AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
+    -e 's/$AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
+    -e 's/$AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
+    -e 's/\[id=.*\]/\[id=<REDACTED>\]/g' \
+    -e 's/::[0-9]\{12\}:/::REDACTED:/g' \
+    -e 's/:[0-9]\{12\}:/:REDACTED:/g'


### PR DESCRIPTION
Removes the use of tee from the workflow as that was splitting the log output resulting in parts of the workflow log not being redacted.