### PR TITLE
Update to v6 aws provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ If you're looking to raise an issue with this module, please create a new issue 
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.0 |
 
 ## Modules
 

--- a/test/unit-test/versions.tf
+++ b/test/unit-test/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 6.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/versions.tf
+++ b/versions.tf
@@ -1,9 +1,9 @@
 terraform {
   required_providers {
     aws = {
-      version = ">= 4.0"
+      version = "~> 6.0"
       source  = "hashicorp/aws"
     }
   }
-  required_version = ">= 1.0.1"
+  required_version = "~> 1.0"
 }


### PR DESCRIPTION
as part of https://github.com/ministryofjustice/modernisation-platform/issues/10509 this PR bumps the module to v6 of the AWS provider