### PR TITLE
Use environment variable for AWS region in Go tests workflow

### DIFF
--- a/.github/workflows/go-terratest.yml
+++ b/.github/workflows/go-terratest.yml
@@ -6,6 +6,7 @@ env:
   TF_IN_AUTOMATION: true
   MODERNISATION_PLATFORM_ACCOUNT_NUMBER: ${{ secrets.MODERNISATION_PLATFORM_ACCOUNT_NUMBER }}
   PASSPHRASE: ${{ secrets.PASSPHRASE }}
+  AWS_REGION: eu-west-2
 
 permissions: {}
 
@@ -45,7 +46,7 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions-testing
           role-session-name: terratest-oidc
-          aws-region: eu-west-2
+          aws-region: ${{ env.AWS_REGION }}
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:


### PR DESCRIPTION
See slack thread https://mojdt.slack.com/archives/C013RM6MFFW/p1776760217572699

This PR updates the testing workflow to specify the AWS region as a global env variable.